### PR TITLE
wandbox help require subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ positional arguments:
     lang                show support languages. see `lang -h`
     option              show compiler options. see `option -h`
     permlink            get permlink. see `permlink -h`
-    run                 build and run command. see `run -h`
-    help                see `help -h`
+    run                 build and run command. see `run +h`
+    help                show subcommand help. see `help -h`
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -69,8 +69,8 @@ positional arguments:
     lang                show support languages. see `lang -h`
     option              show compiler options. see `option -h`
     permlink            get permlink. see `permlink -h`
-    run                 build and run command. see `run -h`
-    help                see `help -h`
+    run                 build and run command. see `run +h`
+    help                show subcommand help. see `help -h`
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/wandbox/cli.py
+++ b/wandbox/cli.py
@@ -135,7 +135,7 @@ class CLI:
         sys.exit(b)
 
     def command_help(self, args):
-        print(self.parser.parse_args(['--help']))
+        print(self.parser.parse_args([args.subcommand[0], '--help']))
 
     # command line option
     def setup(self, lang, compiler):
@@ -267,8 +267,15 @@ class CLI:
             help='comiple command options'
         )
 
-        help_cmd = subparser.add_parser('help', help='see `help -h`')
+        subcommands = self.parser.format_usage().split('{')[1].split('}')[0]
+        help_cmd = subparser.add_parser('help', help='show subcommand help. see `help -h`')
         help_cmd.set_defaults(handler=self.command_help)
+        help_cmd.add_argument(
+            'subcommand',
+            nargs=1,
+            help='subcommand name {' + subcommands + '}'
+        )
+        help_cmd.usage = help_cmd.format_usage().replace('subcommand', 'subcommand{' + subcommands + '}')
 
     def parse_command_line(self):
         args = self.parser.parse_args()

--- a/wandbox/cli.py
+++ b/wandbox/cli.py
@@ -275,7 +275,7 @@ class CLI:
             nargs=1,
             help='subcommand name {' + subcommands + '}'
         )
-        help_cmd.usage = help_cmd.format_usage().replace('subcommand', 'subcommand{' + subcommands + '}')
+        help_cmd.usage = help_cmd.format_usage().replace('usage: ', '').replace('subcommand', 'subcommand{' + subcommands + '}')
 
     def parse_command_line(self):
         args = self.parser.parse_args()

--- a/wandbox/cli.py
+++ b/wandbox/cli.py
@@ -275,7 +275,8 @@ class CLI:
             nargs=1,
             help='subcommand name {' + subcommands + '}'
         )
-        help_cmd.usage = help_cmd.format_usage().replace('usage: ', '').replace('subcommand', 'subcommand{' + subcommands + '}')
+        help_cmd_default_usage = help_cmd.format_usage().replace('usage: ', '')
+        help_cmd.usage = help_cmd_default_usage.replace('subcommand', 'subcommand{' + subcommands + '}')
 
     def parse_command_line(self):
         args = self.parser.parse_args()


### PR DESCRIPTION
fixed: #3 

```
$ wandbox help
usage: wandbox help [-h] subcommand{list,compiler,lang,option,permlink,run}
wandbox help: error: the following arguments are required: subcommand
```

```
$ wandbox help permlink
usage: wandbox permlink [-h] id

get permlink

positional arguments:
  id          permlink id

optional arguments:
  -h, --help  show this help message and exit
```